### PR TITLE
Skill icon hover hint and sorting

### DIFF
--- a/gamedata/configs/text/eng/ui_st_skills_haruka.xml
+++ b/gamedata/configs/text/eng/ui_st_skills_haruka.xml
@@ -2,14 +2,26 @@
 	<string id="st_player_skills_strength">
 		<text>Strength</text>
 	</string>
+	<string id="st_player_skills_hint_strength">
+		<text>Grants increased carry weight and melee damage.\n \nLevels are gained for traveling with heavy loads.</text>
+	</string>
 	<string id="st_player_skills_endurance">
 		<text>Endurance</text>
+	</string>
+	<string id="st_player_skills_hint_endurance">
+		<text>Grants increased stamina and speed.\n \nLevels are gained by traveling light.</text>
 	</string>
 	<string id="st_player_skills_survival">
 		<text>Survival</text>
 	</string>
+	<string id="st_player_skills_hint_survival">
+		<text>Grants increased drops from stalkers.\n \nLevels are gained by looting stalkers.</text>
+	</string>
 	<string id="st_player_skills_scavenging">
 		<text>Scavenging</text>
+	</string>
+	<string id="st_player_skills_hint_scavenging">
+		<text>Grants increased damage resistance and chance to get additional part when skinning.\n \nLevels are gained by taking damage (only bullets and mutants damage) and killing mutants.</text>
 	</string>
     <string id="st_haruka_skills_main">
 		<text>Character Skills</text>

--- a/gamedata/scripts/ui_haru_skills.script
+++ b/gamedata/scripts/ui_haru_skills.script
@@ -68,11 +68,12 @@ function UIHarukaSkills:InitControls()
 	lang = languages[lang] and lang or "eng"
     local cap_main = xml:InitStatic("skills:cap_main_" .. lang, self.dialog)
 	scale_ui(cap_main, true, background, "center")
+	self.hint_wnd = utils_ui.UIHint(self)
     self.scroll = xml:InitScrollView("skills:scroll", self.dialog)
     self.scroll:Clear()
 	self.skills = {}
     local skills_levels = haru_skills.skills_levels
-    for skill, stats in spairs(skills_levels) do
+    for skill, stats in spairs(skills_levels, function(t,a,b) return translate_string("st_player_skills_" .. tostring(a)) < translate_string("st_player_skills_" .. tostring(b)) end) do
         local _st = xml:InitStatic("skills:st", nil)
 		self.skills[skill] = {}
 		self.skills[skill].icon = xml:InitStatic("skills:icon_skill", _st)
@@ -87,6 +88,20 @@ function UIHarukaSkills:InitControls()
     end
 	self:Reset()
 	self:AllowMovement(true)
+end
+
+function UIHarukaSkills:Update()
+	CUIScriptWnd.Update(self)
+	
+	-- Show hint on hover
+	for skill, v in pairs(self.skills) do
+		if self.skills[skill].icon:IsCursorOverWindow() then
+			self.hint_wnd:Update(translate_string("st_player_skills_hint_" .. skill))
+			return
+		end
+	end
+	
+	self.hint_wnd:Update()
 end
 
 function UIHarukaSkills:Reset()


### PR DESCRIPTION
When hovering over a skill icon it shows a hint with a description of the skill.
Added hint strings to xml file.
Changed skill list sorting to sort by skill name in xml, instead of internal name from .ltx